### PR TITLE
Fix Unintended CSV Column Creation in LLM Prompt

### DIFF
--- a/core.py
+++ b/core.py
@@ -149,7 +149,7 @@ class AutoCrew():
             f'Create a dataset in a CSV format with each field enclosed in double quotes, '
             f'for a team of agents. Overall goal for the team is: "{overall_goal}". '
             f'You need to design agents that will work effectively and collaboratively to achieve the team goal successfully. '
-            f'Agents are identified by their role. You must provide each agent in your team the title of their role, their individual goal within the team, their personal backstory and individual skillset, specific details of a task assigned to them which will help ensure the team goal is completed successfully, and whether or not the agent is permitted to delegate certain duties to other agents (True/False). '
+            f'Agents are identified by their role. You must provide each agent in your team the title of their role, their individual goal within the team, their personal backstory, specific details of a task assigned to them which will help ensure the team goal is completed successfully, and whether or not the agent is permitted to delegate certain duties to other agents (True/False). '
             f'Your CSV must contain the columns "role", "goal", "backstory", "assigned_task", "allow_delegation". '
             f'Use the delimiter "{delimiter}" to separate the fields. '
             f'Maintain consistent formatting. Each agent\'s details should be in quotes to avoid confusion with the delimiter. '


### PR DESCRIPTION
In my recent use of AutoCrew, I encountered an [issue](https://github.com/yanniedog/Autocrew/issues/49) where the LLM (`gpt-4-turbo-preview`) was generating an unintended 'skillset' column in the CSV outputs. This occurred because the term 'skillset' was included in the user prompt, leading the LLM to interpret it as an instruction to create an additional column. This resulted in errors when the application attempted to process the CSV data, specifically a `ValueError: No CSV data found in the response`.

To address this, I've made a small yet crucial change in `core.py` by removing the reference to 'individual skillset' from the prompt used to generate responses from the LLM. This change ensures that the output from the LLM aligns with the expected format, preventing the creation of an unexpected 'skillset' column in the CSV output.

This fix is essential for maintaining the integrity of the data processing flow in AutoCrew, ensuring that users do not encounter errors during script generation. By making this prompt more specific and aligned with the expected CSV format, we can avoid potential disruptions caused by unintended LLM output variations.

I've thoroughly tested this change with various inputs and confirmed that the LLM no longer adds the 'skillset' column, aligning the output with our application's requirements. This fix enhances the robustness of AutoCrew's data processing capabilities and ensures a smoother user experience.

I believe this change is a valuable improvement to AutoCrew and hope it can be merged into the main branch to benefit all users. Thank you for considering this contribution to the project.
